### PR TITLE
Modified docker compose file to add the jar files initially and not at the run time

### DIFF
--- a/projects/flight_data_pyspark_structured_streaming/src/docker-compose.yaml
+++ b/projects/flight_data_pyspark_structured_streaming/src/docker-compose.yaml
@@ -4,6 +4,7 @@ x-spark-common: &spark-common
     - ./jobs:/opt/bitnami/spark/jobs
     - ./mnt/checkpoints:/mnt/spark-checkpoints
     - ./mnt/spark-state:/mnt/spark-state
+    - ./jars:/opt/bitnami/spark/additional-jars
   networks:
     - codewithyu
 

--- a/projects/flight_data_pyspark_structured_streaming/src/jobs/main.py
+++ b/projects/flight_data_pyspark_structured_streaming/src/jobs/main.py
@@ -1,8 +1,8 @@
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import StructType, from_json, col, sum, cast, to_json, struct
+from pyspark.sql.functions import StructType, from_json, col, sum, cast, to_json, struct, count
 from pyspark.sql.types import StringType, StructField, DoubleType, LongType
 
-KAFKA_BROKERS = "localhost:29092,localhost:39092,localhost:49092"
+KAFKA_BROKERS = "kafka-broker-1:19092,kafka-broker-2:19092,kafka-broker-3:19092"
 SOURCE_TOPIC = "financial_transactions"
 AGGREGATES_TOPIC = "transaction_aggregates"
 ANOMALIES_TOPIC = "transaction_anomalies"
@@ -17,6 +17,7 @@ spark = (SparkSession.builder
          ).getOrCreate()
 
 spark.sparkContext.setLogLevel("WARN")
+
 
 transaction_schema = StructType([
     StructField('transactionId', StringType(), True),
@@ -36,6 +37,7 @@ kafka_stream = (spark.readStream
                 .option("kafka.bootstrap.servers", KAFKA_BROKERS)
                 .option("subscribe", SOURCE_TOPIC)
                 .option("startingOffsets", "earliest")
+                .option("failOnDataLoss", "false")
                 ).load()
 
 transaction_df = kafka_stream.selectExpr("CAST(value AS STRING)") \
@@ -48,6 +50,7 @@ transaction_df = transaction_df.withColumn('transactionTimestamp',
 aggregated_df = transaction_df.groupBy("merchantId")\
     .agg(
     sum("amount").alias('totalAmount'),
+    count("*").alias("transactionCount")
 )
 
 aggregation_query = (


### PR DESCRIPTION
## Note

- Initially I was running the spark job by providing jar files at the runtime which was inefficient, So I provided jar files at the time of docker compose. At the runtime I am just referencing the jar file location from docker root folders.

## Commands:

1. Run Docker Compose:

```
cd src && docker compose up -d
```

2. Run java kafka producer

```
cd src/utils/java_producers && mvn exec:java -Dexec.mainClass="com.datamasterylab.TransactionProducer"
```

3. Run pyspark job

```
docker exec -it src-spark-master-1 spark-submit \
    --master spark://spark-master:7077 \
    --jars /opt/bitnami/spark/additional-jars/spark-sql-kafka-0-10_2.12-3.5.0.jar,/opt/bitnami/spark/additional-jars/kafka-clients-3.4.1.jar,/opt/bitnami/spark/additional-jars/spark-token-provider-kafka-0-10_2.12-3.5.0.jar,/opt/bitnami/spark/additional-jars/commons-pool2-2.11.1.jar \
    /opt/bitnami/spark/jobs/main.py
```